### PR TITLE
PSEC-2836 enable pre-commit and pull image from artifactory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:   
+  - repo: local
+    hooks:       
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data.
+        entry: bash -c 'trufflehog --no-update git file://. --since-commit HEAD --results=verified,unknown --fail'
+        language: system
+        stages: ["pre-commit", "pre-push"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.16-alpine3.13 as base
+FROM dockerhub.tax.service.gov.uk/golang:1.25-alpine3.22 AS base
 RUN apk add --no-cache \
-    shadow~=4.8 \
-    bash~=5.1
+    shadow \
+    bash
 # UID of current user who runs the build
 ARG user_id
 # GID of current user who runs the build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM dockerhub.tax.service.gov.uk/golang:1.25-alpine3.22 AS base
+FROM dockerhub.tax.service.gov.uk/golang:1.16-alpine3.13 AS base
 RUN apk add --no-cache \
-    shadow \
-    bash
+    shadow~=4.8 \
+    bash~=5.1
 # UID of current user who runs the build
 ARG user_id
 # GID of current user who runs the build
@@ -31,6 +31,7 @@ ENTRYPOINT [ "/usr/local/go/bin/gofmt" ]
 
 FROM base AS go
 ENV CGO_ENABLED=0
+ENV GOPROXY="https://artefacts.tax.service.gov.uk/artifactory/go-packages/"
 COPY go.mod go.sum ${workdir}/
 RUN go mod download
 ENTRYPOINT [ "/usr/local/go/bin/go" ]

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,0 +1,76 @@
+### Pre-commit and TruffleHog Setup Guide
+
+This guide explains how to set up and run TruffleHog v3 with pre-commit on your local machine.
+
+1. Installing TruffleHog locally
+   \[TruffleHog]: https://github.com/trufflesecurity/trufflehog
+
+> Note: You need to make sure you're running TruffleHog v3.
+> Older versions (v2 or below) will not work with the pre-commit hook and may produce errors.
+
+```bash
+trufflehog --version
+# Should show: TruffleHog 3.x.x
+```
+
+2. Install pre-commit
+   Install pre-commit using your preferred method:
+
+* Homebrew:
+
+```bash
+brew install pre-commit
+```
+
+* pip / pipx:
+
+```bash
+pip install pre-commit
+```
+
+3. Enable the Hooks
+   Run this once in the repo root to activate both commit and push hooks:
+
+```bash
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+4. Run the TruffleHog Check
+
+* To scan all files
+
+```bash
+pre-commit run trufflehog --all-files
+```
+
+* To scan only staged changes
+
+```bash
+pre-commit run trufflehog
+```
+
+* To get output in json format
+
+```bash
+trufflehog filesystem . --json
+```
+
+> Note: TruffleHog scan must pass before you can commit or push your changes.
+> This ensures that secrets are not accidentally added to the repository.
+
+### What to Do if the Scan Fails
+
+If TruffleHog detects secrets:
+
+1. Do not commit or push the changes.
+
+2. Review the JSON output to identify the file(s) and reason for detection.
+
+3. Remove or redact the secrets from your code or configuration.
+
+4. If the secret is legitimate and safe to ignore, discuss it with your team before allowing it.
+   You can follow the official TruffleHog documentation for guidance on using the --allow flag to
+   ignore specific files or patterns, creating custom rules to exclude certain secrets, or
+   adding `# trufflehog:ignore` comments directly in code to bypass detection.
+
+5. Re-run the scan to ensure no other secrets are detected before committing or pushing.


### PR DESCRIPTION
- enable pre-commit with truffle hog
- enable use of  artifactory
- installing the latest available versions of shadow and bash without constraining them to specific versions